### PR TITLE
[FIX] account_analytic_dimension_policy: ensure company is set

### DIFF
--- a/account_analytic_dimension_policy/models/account_move_line.py
+++ b/account_analytic_dimension_policy/models/account_move_line.py
@@ -51,6 +51,7 @@ class AccountMoveLine(models.Model):
     @api.depends("analytic_dimension_policy", "parent_state")
     def _compute_analytic_dimension_ui_modifier(self):
         for aml in self:
+            company = aml.company_id or self.env.company
             if aml.analytic_dimension_policy == "never":
                 ui_modifier = "readonly"
             elif aml.analytic_dimension_policy == "always" and aml.parent_state not in (
@@ -64,7 +65,7 @@ class AccountMoveLine(models.Model):
             for dim in dims:
                 fld = "{}_ui_modifier".format(dim)
                 setattr(aml, fld, ui_modifier)
-            all_dims = self._get_all_analytic_dimensions(aml.company_id.id)
+            all_dims = self._get_all_analytic_dimensions(company.id)
             for dim in [x for x in all_dims if x not in dims]:
                 fld = "{}_ui_modifier".format(dim)
                 setattr(aml, fld, False)
@@ -104,7 +105,8 @@ class AccountMoveLine(models.Model):
 
     def _get_analytic_dimensions(self):
         self.ensure_one()
-        all_dims = self._get_all_analytic_dimensions(self.company_id.id)
+        company = self.company_id or self.env.company
+        all_dims = self._get_all_analytic_dimensions(company.id)
         aml_dims = self.analytic_dimensions
         dims = aml_dims and [str(x) for x in aml_dims.split(",")] or all_dims
         return dims


### PR DESCRIPTION
After Odoo V13, all fields  computed must be pass a default value always, Company on `account.move.line` is related of parent(`account.move`), when create a new journal entry, field is empty(False), If analytic dimension has company fill, at search this return empty recordset. This commit ensure taken company of account.move.line or enviroment's company

* Create one dimension policy with field company_id set
* Try create a new Journal entry, get error because compute fields is not set on all fields

![image](https://user-images.githubusercontent.com/7775116/158218407-f488bfe2-a4f7-44ce-964d-25b14688f5cd.png)

![image](https://user-images.githubusercontent.com/7775116/158218248-8310f2aa-5ca4-4857-aded-64fc7245fc25.png)
